### PR TITLE
changes to the documentation

### DIFF
--- a/Chapter03/managing_views/src/views/path.rs
+++ b/Chapter03/managing_views/src/views/path.rs
@@ -19,7 +19,7 @@ impl Path {
     /// To use this in a route, we have to reference it:
     ///
     /// ```rust
-    /// let path = Path{base: String::from("/base/")};
+    /// let path = Path{prefix: String::from("/base/")};
     /// app.route(&path.define(String::from("tail/path")), web::get().to(login::login))
     /// ```
     pub fn define(&self, following_path: String) -> String {


### PR DESCRIPTION
the documentation was making a reference to the wrong member
it was referencing base when the actual member is called prefix